### PR TITLE
Add a basic desktop file

### DIFF
--- a/snap/gui/creativecoin.desktop
+++ b/snap/gui/creativecoin.desktop
@@ -1,0 +1,4 @@
+[Desktop Entry]
+Name=creativecoin
+Exec=creativecoin -qwindowtitle "%c"
+Type=Application


### PR DESCRIPTION
This adds a desktop file to the snap, which should make https://build.snapcraft.io/user/creativechain/creativechain-core green.